### PR TITLE
Support absolute path searches

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,33 +3,33 @@
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-	"version": "0.2.0",
-	"configurations": [{
-			"name": "Run Extension",
-			"type": "extensionHost",
-			"request": "launch",
-			"runtimeExecutable": "${execPath}",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}"
-			],
-			"outFiles": [
-				"${workspaceFolder}/out/**/*.js"
-			],
-			"preLaunchTask": "npm: watch"
-		},
-		{
-			"name": "Run Extension Tests",
-			"type": "extensionHost",
-			"request": "launch",
-			"runtimeExecutable": "${execPath}",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}",
-				"--extensionTestsPath=${workspaceFolder}/out/test"
-			],
-			"outFiles": [
-				"${workspaceFolder}/out/test/**/*.js"
-			],
-			"preLaunchTask": "npm: watch"
-		}
-	]
+    "version": "0.2.0",
+    "configurations": [{
+            "name": "Run Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/out/**/*.js"
+            ],
+            "preLaunchTask": "npm: watch"
+        },
+        {
+            "name": "Run Extension Tests",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}",
+                "--extensionTestsPath=${workspaceFolder}/out/test"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/out/test/**/*.js"
+            ],
+            "preLaunchTask": "npm: watch"
+        }
+    ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,20 +1,20 @@
 // See https://go.microsoft.com/fwlink/?LinkId=733558
 // for the documentation about the tasks.json format
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"type": "npm",
-			"script": "watch",
-			"problemMatcher": "$tsc-watch",
-			"isBackground": true,
-			"presentation": {
-				"reveal": "never"
-			},
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			}
-		}
-	]
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "watch",
+            "problemMatcher": "$tsc-watch",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "never"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Example 'tasks.json' file to build project in monorepo with lerna
 * `fileName` returns file name (ex. _readme.md_)
 * `filePath` returns absolute file path (ex _c:/Projects/proj/info/readme.md_)
 * `fileRelativePath` returns file path, relative to workspace (ex _info/readme.md_)
-* `dirName`	returs name of directory containings file (ex. _info_)
+* `dirName` returs name of directory containings file (ex. _info_)
 * `dirPath` returs absolute path to directory containings file (ex. _c:/Projects/proj/info_)
 * `dirRelativePath` returs relative path to directory containings file (ex. _info_)
 * `json` reads file as json object and returns value of property, specified in `PresentationConfig.json` property

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Example 'tasks.json' file to build project in monorepo with lerna
 
 ## Arguments
 
-* `masks` `<string | string[]>` Masks to file search
+* `masks` `<string | string[]>` Masks to file search. Masks starting with `"/"` are searched as absolute paths, not relative to `workspaceFolder`.
 * `display` `<DisplayType | DisplayConfig>` File names presentation type
 * `output` `<DisplayType | DisplayConfig>` Output presentation type
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-    "name": "lunatic-file-picker",
+    "name": "file-picker",
     "displayName": "file-picker",
     "description": "Simple tool select file from your project by name or json content",
-    "version": "0.1.1",
-    "publisher": "DmitriyMuraviov",
+    "version": "0.1.3",
+    "publisher": "dfarley1",
     "repository": {
         "type": "git",
-        "url": "https://github.com/mrLunatic/vsCodeFilePicker.git"
+        "url": "https://github.com/dfarley1/vsCodeFilePicker.git"
     },
     "engines": {
         "vscode": "^1.25.0"

--- a/package.json
+++ b/package.json
@@ -1,52 +1,52 @@
 {
-	"name": "lunatic-file-picker",
-	"displayName": "file-picker",
-	"description": "Simple tool select file from your project by name or json content",
-	"version": "0.1.1",
+    "name": "lunatic-file-picker",
+    "displayName": "file-picker",
+    "description": "Simple tool select file from your project by name or json content",
+    "version": "0.1.1",
     "publisher": "DmitriyMuraviov",
     "repository": {
         "type": "git",
         "url": "https://github.com/mrLunatic/vsCodeFilePicker.git"
     },
-	"engines": {
-		"vscode": "^1.25.0"
-	},
-	"categories": [
-		"Other"
-	],
-	"keywords": [
-		"pick",
-		"file",
-		"inputs"
-	],
-	"activationEvents": [
-		"onCommand:filePicker.pick"
-	],
-	"main": "./out/extension.js",
-	"icon": "images/icon.png",
-	"contributes": {
-		"commands": [
-			{
-				"command": "filePicker.pick",
-				"title": "Pick",
-				"category": "FilePicker"
-			}
-		]
-	},
-	"scripts": {
-		"vscode:prepublish": "npm run compile",
-		"compile": "tsc -p ./",
-		"watch": "tsc -watch -p ./",
-		"postinstall": "node ./node_modules/vscode/bin/install"
-	},
-	"devDependencies": {
-		"@types/node": "^8.10.25",
-		"tslint": "^5.11.0",
-		"typescript": "^2.6.1",
-		"vscode": "^1.1.21"
-	},
-	"dependencies": {
-		"@types/glob": "^7.1.1",
-		"glob": "^7.1.3"
-	}
+    "engines": {
+        "vscode": "^1.25.0"
+    },
+    "categories": [
+        "Other"
+    ],
+    "keywords": [
+        "pick",
+        "file",
+        "inputs"
+    ],
+    "activationEvents": [
+        "onCommand:filePicker.pick"
+    ],
+    "main": "./out/extension.js",
+    "icon": "images/icon.png",
+    "contributes": {
+        "commands": [
+            {
+                "command": "filePicker.pick",
+                "title": "Pick",
+                "category": "FilePicker"
+            }
+        ]
+    },
+    "scripts": {
+        "vscode:prepublish": "npm run compile",
+        "compile": "tsc -p ./",
+        "watch": "tsc -watch -p ./",
+        "postinstall": "node ./node_modules/vscode/bin/install"
+    },
+    "devDependencies": {
+        "@types/node": "^8.10.25",
+        "tslint": "^5.11.0",
+        "typescript": "^2.6.1",
+        "vscode": "^1.1.21"
+    },
+    "dependencies": {
+        "@types/glob": "^7.1.1",
+        "glob": "^7.1.3"
+    }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
-	"compilerOptions": {
-		"module": "commonjs",
-		"target": "es6",
-		"outDir": "out",
-		"lib": ["es6"],
-		"sourceMap": true,
-		"rootDir": "src"
-	},
-	"exclude": ["node_modules", ".vscode-test"]
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "outDir": "out",
+        "lib": ["es6"],
+        "sourceMap": true,
+        "rootDir": "src"
+    },
+    "exclude": ["node_modules", ".vscode-test"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,6 @@
 {
-	"rules": {
-		"indent": [true, "spaces"],
-		"semicolon": [true, "always"]
-	}
+    "rules": {
+        "indent": [true, "spaces"],
+        "semicolon": [true, "always"]
+    }
 }


### PR DESCRIPTION
I'm working in a project where we send generated files to `/depot/out/gen` that exists outside of any workspace folders but I'd still like to be able to open them via a task so I can use the debugger on them. 